### PR TITLE
Fix ESLint issues in summarize handler and app

### DIFF
--- a/netlify/functions/summarize.ts
+++ b/netlify/functions/summarize.ts
@@ -10,7 +10,7 @@ type SupadataChunk = {
 };
 
 type SupadataImmediate = {
-  content: SupadataChunk[];
+  content: SupadataChunk[] | string;
   lang: string;
   availableLangs?: string[];
 };
@@ -22,6 +22,22 @@ type SupadataJobStatus = {
   availableLangs?: string[];
   error?: unknown;
 };
+
+type SupadataResponsePayload = {
+  content?: unknown;
+  lang?: string;
+  availableLangs?: string[];
+};
+
+function getErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+  if (typeof error === "string" && error) {
+    return error;
+  }
+  return fallback;
+}
 
 function formatTimestamp(totalSeconds: number): string {
   const seconds = Math.max(0, Math.floor(totalSeconds));
@@ -51,18 +67,27 @@ async function requestSupadata(
 
   const res = await fetch(url, { headers: { "x-api-key": apiKey } });
   if (res.status === 200) {
-    const json = (await res.json()) as any;
-    // Normalize: Supadata may occasionally return a string content even when text=false
-    if (json && typeof json === "object" && json.content && !Array.isArray(json.content) && typeof json.content === "string") {
+    const payload = (await res.json()) as SupadataResponsePayload;
+    // Normalize: Supadata may occasionally return a string content even when text=false.
+    if (typeof payload.content === "string") {
       return {
-        content: [
-          { text: String(json.content), offset: 0, duration: 0, lang: json.lang || "en" },
-        ],
-        lang: json.lang || "en",
-        availableLangs: json.availableLangs || [],
+        content: payload.content,
+        lang: payload.lang || "en",
+        availableLangs: payload.availableLangs || [],
       } as SupadataImmediate;
     }
-    return json as SupadataImmediate;
+    if (Array.isArray(payload.content)) {
+      return {
+        content: payload.content as SupadataChunk[],
+        lang: payload.lang || "en",
+        availableLangs: payload.availableLangs || [],
+      } as SupadataImmediate;
+    }
+    return {
+      content: [],
+      lang: payload.lang || "en",
+      availableLangs: payload.availableLangs || [],
+    } as SupadataImmediate;
   }
   if (res.status === 202) {
     const json = (await res.json()) as { jobId: string };
@@ -102,7 +127,7 @@ async function pollSupadataJob(
       console.error("Supadata job failed", { jobId, error: json.error });
       throw new Error(`Supadata job failed: ${JSON.stringify(json.error || {})}`);
     }
-    await new Promise((r) => (globalThis as any).setTimeout(r, intervalMs));
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
   }
   console.error("Supadata job polling timed out", { jobId, lastStatus: lastStatus || "unknown" });
   throw new Error(`Supadata job polling timed out (last status: ${lastStatus || "unknown"})`);
@@ -139,8 +164,8 @@ async function getTranscriptWithFallbacks(
       }
       const contentKind: "chunks" | "text" = Array.isArray(immediate.content) ? "chunks" : "text";
       const items = Array.isArray(immediate.content)
-        ? (immediate.content as SupadataChunk[])
-        : ([{ text: String((immediate as any).content || ""), offset: 0, duration: 0, lang: immediate.lang || "en" }] as SupadataChunk[]);
+        ? immediate.content
+        : [{ text: String(immediate.content || ""), offset: 0, duration: 0, lang: immediate.lang || "en" }];
       attempts?.push({
         mode,
         lang,
@@ -151,8 +176,8 @@ async function getTranscriptWithFallbacks(
         contentKind,
       });
       return { items, lang: immediate.lang, availableLangs: immediate.availableLangs || [] };
-    } catch (e: any) {
-      attempts?.push({ mode, lang, outcome: "error", errorMessage: e?.message || String(e) });
+    } catch (e: unknown) {
+      attempts?.push({ mode, lang, outcome: "error", errorMessage: getErrorMessage(e, "Transcript request failed") });
       throw e;
     }
   }
@@ -174,13 +199,17 @@ async function getTranscriptWithFallbacks(
     try {
       const nativeRes = await perform("native");
       if (nativeRes.items.length) result = nativeRes;
-    } catch {}
+    } catch {
+      // Best-effort fallback: continue to "generate" mode.
+    }
   }
   if (!result.items.length && initialMode !== "generate") {
     try {
       const genRes = await perform("generate");
       if (genRes.items.length) result = genRes;
-    } catch {}
+    } catch {
+      // Best-effort fallback: preserve prior result.
+    }
   }
 
   return result;
@@ -440,8 +469,8 @@ Guidelines:
         ...(debugFlag ? { debug: { attempts: debugAttempts, finalLang: lang, availableLangs } } : {}),
       }),
     };
-  } catch (e: any) {
-    const message = e?.message || "Failed to process transcript";
+  } catch (e: unknown) {
+    const message = getErrorMessage(e, "Failed to process transcript");
     console.error("summarize error", { url: srcUrl, message, error: e });
     return {
       statusCode: 500,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,10 @@ type ApiResponse = {
   truncated?: boolean
 }
 
+type NavigatorWithShare = Navigator & {
+  share: (data?: ShareData) => Promise<void>
+}
+
 const API_BASE = import.meta.env.VITE_API_BASE || '/api'
 
 function isSupportedVideoUrl(input: string): boolean {
@@ -22,6 +26,16 @@ function isSupportedVideoUrl(input: string): boolean {
     // allow bare YouTube IDs
     return /^[a-zA-Z0-9_-]{11}$/.test(input)
   }
+}
+
+function getErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof Error && error.message) return error.message
+  if (typeof error === 'string' && error) return error
+  return fallback
+}
+
+function supportsWebShare(nav: Navigator): nav is NavigatorWithShare {
+  return typeof (nav as Navigator & { share?: unknown }).share === 'function'
 }
 
 function App() {
@@ -48,12 +62,12 @@ function App() {
     setData(null)
     setError(null)
     setIsSubmitting(false)
-    try { window.scrollTo({ top: 0, behavior: 'smooth' }) } catch {}
+    try { window.scrollTo({ top: 0, behavior: 'smooth' }) } catch { /* Ignore unsupported smooth-scroll contexts. */ }
     setTimeout(() => inputRef.current?.focus(), 50)
   }
 
   useEffect(() => {
-    setCanShare(Boolean((navigator as any)?.share))
+    setCanShare(supportsWebShare(navigator))
   }, [])
 
   useEffect(() => {
@@ -88,8 +102,8 @@ function App() {
       }
       const json: ApiResponse = await res.json()
       setData(json)
-    } catch (err: any) {
-      setError(err?.message || 'Failed to summarize video')
+    } catch (err: unknown) {
+      setError(getErrorMessage(err, 'Failed to summarize video'))
     } finally {
       setIsSubmitting(false)
     }
@@ -100,19 +114,23 @@ function App() {
   async function copy(text: string) {
     try {
       await navigator.clipboard.writeText(text)
-    } catch {}
+    } catch {
+      // Copy failures are non-fatal (e.g., blocked clipboard permissions).
+    }
   }
 
   async function shareWithAI() {
     try {
-      if (!canShare || !data?.transcript) return
-      const shareData: any = {
+      if (!canShare || !data?.transcript || !supportsWebShare(navigator)) return
+      const shareData: ShareData = {
         title: 'Video transcript',
         text: data.transcript,
       }
-      if (url) (shareData as any).url = url
-      await (navigator as any).share(shareData)
-    } catch {}
+      if (url) shareData.url = url
+      await navigator.share(shareData)
+    } catch {
+      // Ignore when user cancels native share sheet or API errors.
+    }
   }
 
   return (
@@ -238,7 +256,7 @@ function renderRichSummary(text: string): string {
   }
   // Wrap consecutive <li> into <ul>
   const joined = html.join('\n')
-  const ulWrapped = joined.replace(/(?:<li>[\s\S]*?<\/li>\n?)+/g, (m) => `<ul class=\"list\">\n${m}\n<\/ul>\n`)
+  const ulWrapped = joined.replace(/(?:<li>[\s\S]*?<\/li>\n?)+/g, (m) => `<ul class="list">\n${m}\n</ul>\n`)
   return ulWrapped
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- replace explicit `any` usages in `netlify/functions/summarize.ts` and `src/App.tsx` with safer `unknown` handling and typed helpers
- remove empty `catch` blocks by adding intentional no-op handling comments where failures are expected/non-fatal
- clean up unnecessary escape characters in `renderRichSummary` list wrapping HTML template

## Validation
- `npm run lint`
- `npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bffebd55-9752-45bd-bfbb-542351ef66b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bffebd55-9752-45bd-bfbb-542351ef66b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

