### PR TITLE
Harden summarize function against upstream latency and silent timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,20 @@ npm run dev
 - Some videos have no transcripts; the app informs the user.
 - Very long transcripts are truncated before summarization for responsiveness.
 - Transcripts are fetched from Supadata (`mode=auto`) and will be in the video's default language, preferring English when available.
+
+## Troubleshooting 502/504 on "Summarize"
+
+The summarize path is synchronous (`/api/summarize`) and can time out if transcript retrieval or model inference is slow.
+
+This function now supports tuning env vars:
+
+- `SUMMARIZE_DEADLINE_MS` (default `23000`): overall internal deadline before returning a controlled timeout.
+- `GEMINI_TIMEOUT_MS` (default `12000`): max time spent waiting for Gemini response.
+- `MAX_TRANSCRIPT_MODEL_CHARS` (default `60000`): transcript size sent to Gemini.
+- `MAX_TRANSCRIPT_RESPONSE_CHARS` (default `120000`): transcript size returned to the browser.
+
+If you still see 502/504:
+- Check function logs for `summarize request started`, `summarize transcript ready`, and `summarize timeout` entries.
+- Try shorter videos first to confirm behavior.
+- Temporarily send `{ "debug": true }` in request body to include transcript-attempt diagnostics in JSON responses.
+- Verify `SUPADATA_API_KEY` and `GEMINI_API_KEY` are present and valid in Netlify environment variables.

--- a/netlify/functions/summarize.ts
+++ b/netlify/functions/summarize.ts
@@ -29,6 +29,81 @@ type SupadataResponsePayload = {
   availableLangs?: string[];
 };
 
+class StageTimeoutError extends Error {
+  stage: string;
+  timeoutMs: number;
+
+  constructor(stage: string, timeoutMs: number) {
+    super(`${stage} timed out after ${timeoutMs}ms`);
+    this.name = "StageTimeoutError";
+    this.stage = stage;
+    this.timeoutMs = timeoutMs;
+  }
+}
+
+class DeadlineExceededError extends Error {
+  stage: string;
+  remainingMs: number;
+
+  constructor(stage: string, remainingMs: number) {
+    super(`${stage} skipped because request deadline was exceeded (${remainingMs}ms remaining)`);
+    this.name = "DeadlineExceededError";
+    this.stage = stage;
+    this.remainingMs = remainingMs;
+  }
+}
+
+function isTimeoutLikeError(error: unknown): error is StageTimeoutError | DeadlineExceededError {
+  return error instanceof StageTimeoutError || error instanceof DeadlineExceededError;
+}
+
+function getEnvPositiveInt(name: string, fallback: number): number {
+  const raw = process?.env?.[name];
+  if (!raw) return fallback;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return Math.floor(parsed);
+}
+
+function getEffectiveTimeoutMs(preferredMs: number, stage: string, deadlineAt?: number): number {
+  if (!deadlineAt) return preferredMs;
+  const remaining = deadlineAt - Date.now();
+  if (remaining <= 500) {
+    throw new DeadlineExceededError(stage, remaining);
+  }
+  return Math.max(750, Math.min(preferredMs, remaining - 250));
+}
+
+async function fetchWithTimeout(url: string, init: Parameters<typeof fetch>[1], timeoutMs: number, stage: string) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...(init || {}), signal: controller.signal });
+  } catch (error: unknown) {
+    if (
+      (error as { name?: string })?.name === "AbortError" ||
+      (error as { code?: string })?.code === "ABORT_ERR"
+    ) {
+      throw new StageTimeoutError(stage, timeoutMs);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function promiseWithTimeout<T>(promise: Promise<T>, timeoutMs: number, stage: string): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const timeoutPromise = new Promise<T>((_, reject) => {
+      timeout = setTimeout(() => reject(new StageTimeoutError(stage, timeoutMs)), timeoutMs);
+    });
+    return await Promise.race([promise, timeoutPromise]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
 function getErrorMessage(error: unknown, fallback: string): string {
   if (error instanceof Error && error.message) {
     return error.message;
@@ -60,12 +135,19 @@ function isSupportedVideoUrl(input: string): boolean {
 async function requestSupadata(
   videoUrl: string,
   apiKey: string,
-  opts?: { lang?: string; text?: boolean; mode?: "auto" | "native" | "generate" }
+  opts?: {
+    lang?: string;
+    text?: boolean;
+    mode?: "auto" | "native" | "generate";
+    requestTimeoutMs?: number;
+    deadlineAt?: number;
+  }
 ): Promise<SupadataImmediate | { jobId: string }> {
   let url = `https://api.supadata.ai/v1/transcript?url=${encodeURIComponent(videoUrl)}&text=${String(opts?.text ?? false)}&mode=${encodeURIComponent(opts?.mode ?? "auto")}`;
   if (opts?.lang) url += `&lang=${encodeURIComponent(opts.lang)}`;
 
-  const res = await fetch(url, { headers: { "x-api-key": apiKey } });
+  const timeoutMs = getEffectiveTimeoutMs(opts?.requestTimeoutMs ?? 9_000, "Supadata transcript request", opts?.deadlineAt);
+  const res = await fetchWithTimeout(url, { headers: { "x-api-key": apiKey } }, timeoutMs, "Supadata transcript request");
   if (res.status === 200) {
     const payload = (await res.json()) as SupadataResponsePayload;
     // Normalize: Supadata may occasionally return a string content even when text=false.
@@ -101,13 +183,24 @@ async function pollSupadataJob(
   jobId: string,
   apiKey: string,
   timeoutMs = 60_000,
-  intervalMs = 1_500
+  intervalMs = 1_500,
+  opts?: { requestTimeoutMs?: number; deadlineAt?: number }
 ): Promise<SupadataImmediate> {
   const endpoint = `https://api.supadata.ai/v1/transcript/${jobId}`;
   const started = Date.now();
   let lastStatus = "";
   while (Date.now() - started < timeoutMs) {
-    const res = await fetch(endpoint, { headers: { "x-api-key": apiKey } });
+    const requestTimeoutMs = getEffectiveTimeoutMs(
+      opts?.requestTimeoutMs ?? 7_000,
+      "Supadata transcript polling",
+      opts?.deadlineAt
+    );
+    const res = await fetchWithTimeout(
+      endpoint,
+      { headers: { "x-api-key": apiKey } },
+      requestTimeoutMs,
+      "Supadata transcript polling"
+    );
     if (!res.ok) {
       const t = await res.text();
       console.error("Supadata job polling HTTP error", { jobId, status: res.status, text: t });
@@ -126,6 +219,14 @@ async function pollSupadataJob(
     if (json.status === "failed") {
       console.error("Supadata job failed", { jobId, error: json.error });
       throw new Error(`Supadata job failed: ${JSON.stringify(json.error || {})}`);
+    }
+    if (opts?.deadlineAt) {
+      const remaining = opts.deadlineAt - Date.now();
+      if (remaining <= 500) {
+        throw new DeadlineExceededError("Supadata transcript polling", remaining);
+      }
+      await new Promise((resolve) => setTimeout(resolve, Math.min(intervalMs, Math.max(250, remaining - 250))));
+      continue;
     }
     await new Promise((resolve) => setTimeout(resolve, intervalMs));
   }
@@ -147,18 +248,32 @@ type TranscriptAttemptRecord = {
 async function getTranscriptWithFallbacks(
   videoUrl: string,
   apiKey: string,
-  opts?: { preferEnglish?: boolean; forceMode?: "auto" | "native" | "generate"; debugAttempts?: TranscriptAttemptRecord[] }
+  opts?: {
+    preferEnglish?: boolean;
+    forceMode?: "auto" | "native" | "generate";
+    debugAttempts?: TranscriptAttemptRecord[];
+    deadlineAt?: number;
+  }
 ): Promise<{ items: SupadataChunk[]; lang: string; availableLangs: string[] }> {
   const preferEnglish = opts?.preferEnglish !== false;
   const attempts = opts?.debugAttempts;
 
   async function perform(mode: "auto" | "native" | "generate", lang?: string) {
     try {
-      const first = await requestSupadata(videoUrl, apiKey, { text: false, mode, lang });
+      const first = await requestSupadata(videoUrl, apiKey, {
+        text: false,
+        mode,
+        lang,
+        requestTimeoutMs: 9_000,
+        deadlineAt: opts?.deadlineAt,
+      });
       let immediate: SupadataImmediate;
       if ("jobId" in first) {
         attempts?.push({ mode, lang, outcome: "job" });
-        immediate = await pollSupadataJob(first.jobId, apiKey);
+        immediate = await pollSupadataJob(first.jobId, apiKey, 60_000, 1_500, {
+          requestTimeoutMs: 7_000,
+          deadlineAt: opts?.deadlineAt,
+        });
       } else {
         immediate = first as SupadataImmediate;
       }
@@ -339,6 +454,9 @@ const handler: Handler = async (event) => {
   let srcUrl: string | undefined;
   let debugFlag = false;
   let forceMode: "auto" | "native" | "generate" | undefined;
+  const requestId = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+  const overallDeadlineMs = getEnvPositiveInt("SUMMARIZE_DEADLINE_MS", 23_000);
+  const deadlineAt = Date.now() + overallDeadlineMs;
   try {
     const body = event.body ? JSON.parse(event.body) : {};
     srcUrl = body.url;
@@ -394,6 +512,7 @@ const handler: Handler = async (event) => {
   }
 
   try {
+    console.info("summarize request started", { requestId, url: srcUrl, forceMode, overallDeadlineMs, debug: debugFlag });
     let requestUrl = srcUrl;
     if (/^[a-zA-Z0-9_-]{11}$/.test(srcUrl)) {
       requestUrl = `https://youtu.be/${srcUrl}`;
@@ -403,6 +522,7 @@ const handler: Handler = async (event) => {
       preferEnglish: true,
       forceMode,
       debugAttempts,
+      deadlineAt,
     });
     if (!items?.length) {
       console.warn("No transcript found", { url: requestUrl, debugAttempts, lang, availableLangs });
@@ -423,9 +543,14 @@ const handler: Handler = async (event) => {
       })
       .join("\n");
 
-    const MAX_CHARS = 180_000;
-    const truncated = transcriptText.length > MAX_CHARS;
-    const transcriptForModel = truncated ? transcriptText.slice(0, MAX_CHARS) : transcriptText;
+    const maxModelChars = getEnvPositiveInt("MAX_TRANSCRIPT_MODEL_CHARS", 60_000);
+    const maxResponseChars = getEnvPositiveInt("MAX_TRANSCRIPT_RESPONSE_CHARS", 120_000);
+    const truncated = transcriptText.length > maxModelChars;
+    const transcriptForModel = truncated ? transcriptText.slice(0, maxModelChars) : transcriptText;
+    const responseTranscriptTruncated = transcriptText.length > maxResponseChars;
+    const transcriptForResponse = responseTranscriptTruncated
+      ? transcriptText.slice(0, maxResponseChars)
+      : transcriptText;
 
     const ai = new GoogleGenAI({ apiKey: geminiApiKey });
     const systemInstruction = `You are an expert at creating concise, structured summaries of videos from transcripts.
@@ -444,16 +569,33 @@ Guidelines:
       ? "The transcript was truncated due to length. Summarize the provided portion faithfully."
       : "Summarize the transcript faithfully.";
 
-    const response = await ai.models.generateContent({
-      model: "gemini-3-flash-preview",
-      contents: userInstruction + "\n\nTRANSCRIPT:\n" + transcriptForModel,
-      config: {
-        systemInstruction,
-        thinkingConfig: {
-          thinkingLevel: ThinkingLevel.LOW,
-        },
-      },
+    const geminiTimeoutMs = getEffectiveTimeoutMs(
+      getEnvPositiveInt("GEMINI_TIMEOUT_MS", 12_000),
+      "Gemini summarization",
+      deadlineAt
+    );
+    console.info("summarize transcript ready", {
+      requestId,
+      itemCount: items.length,
+      transcriptLength: transcriptText.length,
+      modelTranscriptLength: transcriptForModel.length,
+      geminiTimeoutMs,
+      responseTranscriptTruncated,
     });
+    const response = await promiseWithTimeout(
+      ai.models.generateContent({
+        model: "gemini-3-flash-preview",
+        contents: userInstruction + "\n\nTRANSCRIPT:\n" + transcriptForModel,
+        config: {
+          systemInstruction,
+          thinkingConfig: {
+            thinkingLevel: ThinkingLevel.LOW,
+          },
+        },
+      }),
+      geminiTimeoutMs,
+      "Gemini summarization"
+    );
     const summary = response.text ?? "";
 
     const maybeVideoId = extractYouTubeVideoIdOptional(srcUrl) || "";
@@ -464,14 +606,26 @@ Guidelines:
       body: JSON.stringify({
         videoId: maybeVideoId,
         summary,
-        transcript: transcriptText,
+        transcript: transcriptForResponse,
         truncated,
+        responseTranscriptTruncated,
         ...(debugFlag ? { debug: { attempts: debugAttempts, finalLang: lang, availableLangs } } : {}),
       }),
     };
   } catch (e: unknown) {
     const message = getErrorMessage(e, "Failed to process transcript");
-    console.error("summarize error", { url: srcUrl, message, error: e });
+    if (isTimeoutLikeError(e)) {
+      console.error("summarize timeout", { requestId, url: srcUrl, message, error: e });
+      return {
+        statusCode: 504,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          error: "Summarization timed out before completion. Try a shorter video or try again in a moment.",
+          ...(debugFlag ? { detail: message } : {}),
+        }),
+      };
+    }
+    console.error("summarize error", { requestId, url: srcUrl, message, error: e });
     return {
       statusCode: 500,
       headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add stage-level timeout controls for Supadata requests/polling and Gemini generation
- add an overall internal summarize deadline so the function returns a controlled JSON timeout instead of hanging until platform timeout
- reduce default transcript payload size sent to Gemini and returned to the client to lower latency/response size risk
- add request lifecycle logging (`summarize request started`, `summarize transcript ready`, `summarize timeout`) for easier Netlify troubleshooting
- document new timeout/truncation environment variables and 502/504 troubleshooting steps in README

## Why
Users were seeing long-running summarize requests that eventually surfaced as 502/504 with little diagnostic data. This change makes failures explicit and faster, and improves observability.

## Validation
- `npm run build`
- `npm run lint`

## Config
New optional env vars:
- `SUMMARIZE_DEADLINE_MS` (default `23000`)
- `GEMINI_TIMEOUT_MS` (default `12000`)
- `MAX_TRANSCRIPT_MODEL_CHARS` (default `60000`)
- `MAX_TRANSCRIPT_RESPONSE_CHARS` (default `120000`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-220a06c3-0640-4bbe-81ae-bc0d7c99be84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-220a06c3-0640-4bbe-81ae-bc0d7c99be84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

